### PR TITLE
Includes improved testing and bug fixes related to nested parameterized roles.

### DIFF
--- a/lib/Meta/Grapher/Moose.pm
+++ b/lib/Meta/Grapher/Moose.pm
@@ -220,7 +220,7 @@ sub _add_edge_to_graph {
     # which are actually implemented as TWO roles. _node_label_for() helps us
     # collapse these roles into a single node on the graph by having them share
     # a name. Here, we use a short-circuit return to hide the link between them.
-    my ($from,$to) = map { $args{$_} } qw( from to );
+    my ( $from, $to ) = map { $args{$_} } qw( from to );
     return if $from eq $to;
 
     my $key = join "\0", @args{ 'from', 'to' };

--- a/lib/Meta/Grapher/Moose.pm
+++ b/lib/Meta/Grapher/Moose.pm
@@ -5,7 +5,7 @@ use warnings;
 use autodie;
 use namespace::autoclean;
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 use Getopt::Long;
 use GraphViz2;
@@ -214,6 +214,14 @@ sub _add_edge_to_graph {
     my %args = @_;
 
     $args{$_} = $self->_node_label_for( $args{$_} ) for qw( from to );
+
+    # This is not a paranoid check for recursive inheiritance. We are actually
+    # looking for a case that will happen when processing parametized roles,
+    # which are actually implemented as TWO roles. _node_label_for() helps us
+    # collapse these roles into a single node on the graph by having them share
+    # a name. Here, we use a short-circuit return to hide the link between them.
+    my ($from,$to) = map { $args{$_} } qw( from to );
+    return if $from eq $to;
 
     my $key = join "\0", @args{ 'from', 'to' };
     return if $self->_already_saw_edge($key);

--- a/t/edge_tests_for_classes_and_roles.t
+++ b/t/edge_tests_for_classes_and_roles.t
@@ -119,7 +119,7 @@ sub get_package_type {
 
 sub parse_config {
     my ( $config, $result ) = @_;
-    while ( my ( $this, $family ) = each $config ) {
+    while ( my ( $this, $family ) = each %$config ) {
 
         # Validate our configuration 'syntax'
         die 'Bad config (expects each key to be a hashref or "1")!'

--- a/t/edge_tests_for_classes_and_roles.t
+++ b/t/edge_tests_for_classes_and_roles.t
@@ -145,7 +145,7 @@ sub parse_config {
         $result = parse_config( $family, $result );
 
         # Update our expecations
-        print $this. '(' . ( scalar @relations ) . '): $package' . "\n"
+        print $this. '(' . ( scalar @relations ) . "): $package" . "\n"
             || die
             if $DEBUG;
         push @relations, 'Moose::Object'

--- a/t/edge_tests_for_classes_and_roles.t
+++ b/t/edge_tests_for_classes_and_roles.t
@@ -1,0 +1,157 @@
+## no critic (Modules)
+use warnings;
+use strict;
+use version;
+use lib '../lib';
+use File::Temp qw(tempfile);
+use Scalar::Util qw(reftype);
+use Data::Dumper;
+use Test::More tests => 31;
+use Storable qw(dclone);
+
+my $DEBUG = $ARGV[0];    # this will double as the location to store the graph
+
+### Testing begin now.
+use_ok( 'Meta::Grapher::Moose', qv('v0.3')->numify );
+
+my $test_config = {
+    ClassA => {
+        ClassB => { RoleA => { RoleB => { RoleC => 1, RoleD => 1 } } },
+        ClassC => {
+            ClassD => 1,
+            ParamRoleW =>
+                { ParamRoleX => 1, ParamRoleY => { ParamRoleZ => 1 } }
+        },
+    },
+};
+
+print 'Test Config: ' . Dumper($test_config) || die if $DEBUG;
+
+my $parsed = { packages => [], edges => [] };
+$parsed = parse_config( $test_config, $parsed );
+
+print 'Parsed Config: ' . Dumper($parsed) || die if $DEBUG;
+
+foreach my $package_string ( @{ $parsed->{packages} } ) {
+    my ( $parent, $package ) = split m/\0/, $package_string;
+    ## no critic (BuiltinFunctions::ProhibitStringyEval)
+    eval "$package" or die $@;
+    use_ok($parent);
+    new_ok($parent) if $parent =~ m/class/i;
+}
+
+# List context is needed to get the path which we need, but list context
+#  also returns the file handle (e.g. $fh), which we don't need.
+my ( undef, $temp_filename ) = tempfile();
+
+# Use whatever was provided as the DEBUG, if anything was provided.
+my $filename = $DEBUG ? $DEBUG : $temp_filename;
+
+my $meta_graph = new_ok(
+    'Meta::Grapher::Moose',
+    [ output => $filename, package => 'ClassA' ]
+);
+$meta_graph->run;
+my $got = dclone $meta_graph->{_edges};
+
+print 'Obtained Graph Edges: ' . Dumper($got) || die if $DEBUG;
+
+foreach my $expected_edge ( @{ $parsed->{edges} } ) {
+    my ( $from, $to ) = split m/\0/, $expected_edge;
+    my $found_edge = delete $got->{$expected_edge};
+    ok( defined $found_edge, "Got the expected edge between $from and $to." );
+}
+
+foreach my $extra_edge ( keys %$got ) {
+    my ( $from, $to ) = split /\0/, $extra_edge;
+    fail("Unexpected edge between $from and $to!");
+}
+
+exit;    # Done testing.
+
+### Supporting Subroutines
+sub convert_to_package_string {
+    my ( $from, @to_list ) = @_;
+    my $package = "{ package $from; ";
+    my $type    = get_package_type($from);
+    $package .= "use $type; ";
+    $package .= 'role { ' if $from =~ m/param/i;
+    my ( @roles, @parents );
+    foreach my $to (@to_list) {
+        if ( $to =~ m/class/i ) {
+            push @parents, $to;
+        }
+        elsif ( $to =~ m/role/i ) {
+            push @roles, $to;
+        }
+        else {
+            die 'Expected names that include "class" or "role". Not sure '
+                . "how to make '$from' of type '$type' interact with '$to'!";
+        }
+    }
+    if (@parents) {
+        $package .= 'extends "' . ( join '", "', @parents ) . '"; ';
+    }
+    foreach my $role (@roles) {
+        $package .= "with '$role'; ";
+    }
+    $package .= '}; ' if $from =~ m/param/i;
+    $package .= '1; }';
+}
+
+sub get_package_type {
+    my ($from) = @_;
+    my ($type);
+    if ( $from =~ m/class/i ) {
+        $type = 'Moose';
+    }
+    elsif ( $from =~ m/param/i ) {
+        $type = 'MooseX::Role::Parameterized';
+    }
+    elsif ( $from =~ m/role/i ) {
+        $type = 'Moose::Role';
+    }
+    else {
+        die "Could not determine type of '$from'!";
+    }
+    return $type;
+}
+
+sub parse_config {
+    my ( $config, $result ) = @_;
+    while ( my ( $this, $family ) = each $config ) {
+
+        # Validate our configuration 'syntax'
+        die 'Bad config (expects each key to be a hashref or "1")!'
+            if $family != 1 && reftype($family) ne 'HASH';
+        die
+            'Bad config (expects non-empty hash-ref, use "1" instead of "{}")!'
+            if ref $family
+            && reftype($family) eq 'HASH'
+            && 0 == keys %$family;
+
+        # Base recursion case.
+        $family = {} if $family == 1;
+
+        # To process the 'parent' we need just the keys from the nexted
+        # configuration. Later on, we will recurse into the nexted data.
+
+        my @relations = keys %$family;
+
+        # Create and 'use' the package.
+        my $package = convert_to_package_string( $this, @relations );
+
+        # Recursion case.
+        $result = parse_config( $family, $result );
+
+        # Update our expecations
+        print $this. '(' . ( scalar @relations ) . '): $package' . "\n"
+            || die
+            if $DEBUG;
+        push @relations, 'Moose::Object'
+            if $this =~ m/class/i && 0 == grep {m/class/i} @relations;
+        push @{ $result->{edges} }, map { join "\0", $_, $this } @relations;
+        push @{ $result->{packages} }, $this . "\0" . $package;
+    }
+    return $result;
+}


### PR DESCRIPTION
This is the first pull request I've ever made on github, so please let me know if it is incomplete in some way.

A team I work with uses parameterized roles almost exclusively, with very little conventional inheritance. I've been interested in visualizing this for some time, and your module was the first thing I've seen that could even come close. Even so, there appears to be an extra layer of anonymous roles when you are working with an object of 'MooseX::Role::Parameterized::Meta::Role::Parameterized'. The roles it consumes are accessible via ->get_roles, but its user-friendly name is accessible via ->genitor->name. ->genitor->get_roles() is always empty, which meant that the current implementation had a maximum depth of one (in obtaining the name it could no longer 'go back' to obtain the roles).

My changes effectively 'spam' duplicate edges that always use the name the user is interested in. Your existing code filters this down so that only one unique edge is ever added. In the process, all the interesting relationships get edges. 
